### PR TITLE
Fix Markdown emphasis

### DIFF
--- a/_posts/issues/issue-39/2017-01-03-it-happened-to-me-my-doppleganger-stole-my-credit-card-info-and-then-my-life.md
+++ b/_posts/issues/issue-39/2017-01-03-it-happened-to-me-my-doppleganger-stole-my-credit-card-info-and-then-my-life.md
@@ -49,7 +49,7 @@ I tapped my pencil's teddy bear-shaped eraser against the paper, and then slowly
 
 _Dear Nono,_
 
-_Hi! I want to be penpals. We had fun together but I get in less trouble now, so I guess thats good. I miss you too. _
+_Hi! I want to be penpals. We had fun together but I get in less trouble now, so I guess thats good. I miss you too._
 
 _Here are some questions. Whats your favorite TV show? Do you like any boys? Do you go to school where you are and do you hate it?_
 


### PR DESCRIPTION
Extra space between the end of the sentence and '_' caused the emphasis to render incorrectly.